### PR TITLE
Use correct field name for trace identifier.

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -78,7 +78,7 @@ type Entry struct {
 	Timestamp      string          `json:"timestamp,omitempty"`
 	Severity       severity        `json:"severity,omitempty"`
 	HTTPRequest    *HTTPRequest    `json:"httpRequest,omitempty"`
-	Trace          string          `json:"trace,omitempty"`
+	Trace          string          `json:"logging.googleapis.com/trace,omitempty"`
 	ServiceContext *ServiceContext `json:"serviceContext,omitempty"`
 	Message        string          `json:"message,omitempty"`
 	Context        *Context        `json:"context,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/icco/logrus-stackdriver-formatter
+module github.com/charleskorn/logrus-stackdriver-formatter
 
 require (
 	github.com/TV4/logrus-stackdriver-formatter v0.1.0


### PR DESCRIPTION
See https://cloud.google.com/run/docs/logging#correlate-logs
and https://github.com/GoogleCloudPlatform/golang-samples/blob/master/run/logging-manual/main.go#L60.